### PR TITLE
make changes to files for sky-shell-exec to run properly

### DIFF
--- a/core/loader/elfloader.c
+++ b/core/loader/elfloader.c
@@ -193,6 +193,8 @@ find_local_symbol(int fd, const char *symbol,
 	  sect = &bss;
 	} else if(s.st_shndx == data.number) {
 	  sect = &data;
+	} else if(s.st_shndx == rodata.number) {
+	  sect = &rodata;
 	} else if(s.st_shndx == text.number) {
 	  sect = &text;
 	} else {

--- a/cpu/msp430/Makefile.msp430
+++ b/cpu/msp430/Makefile.msp430
@@ -72,6 +72,20 @@ CFLAGSNO = --dlib_config "$(IAR_PATH)/LIB/DLIB/dl430xlfn.h" $(CFLAGSWERROR)
 # CFLAGSNO = --dlib_config $(IAR_PATH)/LIB/DLIB/dl430xlfn.h -Ohz --multiplier=32 --multiplier_location=4C0 --hw_workaround=CPU40 --core=430X $(CFLAGSWERROR) --data_model large --double=32
 endif
 
+LDFLAGSNO += -B -l contiki-$(TARGET).map -s __program_start
+#  Stack and heap size in hex
+ifndef IAR_STACK_SIZE
+IAR_STACK_SIZE=300
+endif
+#  Set this to a positive number (hex) to enable malloc/fre with IAR compiler
+ifndef IAR_DATA16_HEAP_SIZE
+IAR_DATA16_HEAP_SIZE=100
+endif
+ifndef IAR_DATA20_HEAP_SIZE
+IAR_DATA20_HEAP_SIZE=0
+endif
+LDFLAGSNO += -D_STACK_SIZE=$(IAR_STACK_SIZE) -D_DATA16_HEAP_SIZE=$(IAR_DATA16_HEAP_SIZE) -D_DATA
+
 CUSTOM_RULE_C_TO_O = 1
 %.o: %.c
 	$(CC) $(CFLAGS) $< -o $@
@@ -83,7 +97,8 @@ rm -f $(@:.o=.P)
 endef
 
 CUSTOM_RULE_C_TO_OBJECTDIR_O = 1
-$(OBJECTDIR)/%.o: %.c
+#$(OBJECTDIR)/%.o: %.c
+$(OBJECTDIR)/%.o: %.c | $(OBJECTDIR)
 	$(CC) $(CFLAGS) $< --dependencies=m $(@:.o=.P) -o $@
 ifeq ($(HOST_OS),Windows)
 	@$(FINALIZE_CYGWIN_DEPENDENCY)
@@ -129,7 +144,8 @@ ifndef CC_MCU
 endif
 
 ifndef CFLAGSNO
-CFLAGSNO = -Wall -mmcu=$(CC_MCU) -g $(CFLAGSWERROR)
+#CFLAGSNO = -Wall -mmcu=$(CC_MCU) -g $(CFLAGSWERROR)
+CFLAGSNO = -Wall -mmcu=$(CC_MCU) $(CFLAGSWERROR)
 endif
 CFLAGS  += -Os -fno-strict-aliasing
 LDFLAGS += -mmcu=$(CC_MCU) -Wl,-Map=contiki-$(TARGET).map

--- a/examples/sky-shell-exec/Makefile
+++ b/examples/sky-shell-exec/Makefile
@@ -5,7 +5,7 @@ TARGET=sky
 
 DEFINES=ELFLOADER_DATAMEMORY_SIZE=0x100,ELFLOADER_TEXTMEMORY_SIZE=0x100
 
-APPS = serial-shell
+APPS = serial-shell remote-shell
 CONTIKI = ../..
 include $(CONTIKI)/Makefile.include
 

--- a/tools/mknmlist
+++ b/tools/mknmlist
@@ -23,7 +23,7 @@ BEGIN {
  builtin[""] = 	"";
 }
 
-/^[0123456789abcdef]+ [ABCDGRSTUVW] / {
+/^[0123456789abcdef]+ [ABCDGRSTUVW] [^__]/ {
   if ($3 != "symbols" && $3 != "symbols_nelts") {
     name[nname] = $3;
     nname++;


### PR DESCRIPTION
Modified some files supplied by Contiki 2.6 to match those of Contiki 2.7 to enable sky-shell-exec to run.  It should be noted that the msp430-gcc version should be upgraded to 4.7.0 from 4.5.3 in addition to the changed files in order to enable sky-shell-exec to run.
