### PR TITLE
add more memory addr for mpu 6050 and fixed bug in mpu_sample_gyro

### DIFF
--- a/platform/sky/dev/mpu-6050.c
+++ b/platform/sky/dev/mpu-6050.c
@@ -174,7 +174,7 @@ int mpu_sample_acc(mpu_data_acc_gyro_union *sampled_data)
 int mpu_sample_gyro(mpu_data_acc_gyro_union *sampled_data)
 {
 	//uint8_t buffer[6];
-	if(!read_mpu_reg_burst(MPU_RA_ACCEL_XOUT_H,6,(uint8_t*)sampled_data))
+	if(!read_mpu_reg_burst(MPU_RA_GYRO_XOUT_H,6,(uint8_t*)sampled_data))
 		return 0;
 
 	SWAP(sampled_data->reg.x_h,sampled_data->reg.x_l);

--- a/platform/sky/dev/mpu-6050.h
+++ b/platform/sky/dev/mpu-6050.h
@@ -44,6 +44,14 @@
 #define MPU_RA_PWR_MGMT1 0x6b
 #define MPU_RV_PWR_MGMT1_AWAKE 0x00
 #define MPU_RA_PWR_MGMT2 0x6c
+
+#define MPU_SMPLRT_DIV             0x19
+#define MPU_CONFIG                 0x1a
+#define MPU_GYRO_CONFIG            0x1b
+#define MPU_ACCEL_CONFIG           0x1c
+
+
+
 typedef struct
 {
     /* data */


### PR DESCRIPTION
- add more memory address for MPU 6050
- fix bug of mpu_sample_gyro (replace the start addr with gyro addr)
