### PR TITLE
add new functions to read acc and gyro samples from mpu_sample_all()

### DIFF
--- a/platform/sky/dev/mpu-6050.c
+++ b/platform/sky/dev/mpu-6050.c
@@ -283,6 +283,24 @@ void print_mpu_sample_acc_gyro(mpu_data_acc_gyro_union *samples)
 }
 
 
+void mpu_get_acc(mpu_data_union *sampled_data,mpu_data_acc_gyro_union *acc_sample)
+{
+
+	acc_sample->data.x = sampled_data->data.accel_x;
+	acc_sample->data.y = sampled_data->data.accel_y;
+	acc_sample->data.z = sampled_data->data.accel_z;
+
+}
+
+void mpu_get_gyro(mpu_data_union *sampled_data,mpu_data_acc_gyro_union *gyro_sample)
+{
+
+	gyro_sample->data.x = sampled_data->data.gyro_x;
+	gyro_sample->data.y = sampled_data->data.gyro_y;
+	gyro_sample->data.z = sampled_data->data.gyro_z;
+
+}
+
 
 
 

--- a/platform/sky/dev/mpu-6050.h
+++ b/platform/sky/dev/mpu-6050.h
@@ -131,4 +131,7 @@ int mpu_sleep(void);
 void print_mpu_sample(mpu_data_union *samples);
 void print_mpu_sample_acc_gyro(mpu_data_acc_gyro_union *samples);
 
+void mpu_get_acc(mpu_data_union *sampled_data,mpu_data_acc_gyro_union *acc_sample);
+void mpu_get_gyro(mpu_data_union *sampled_data,mpu_data_acc_gyro_union *gyro_sample);
+
 #endif /*MPU_6050_H*/


### PR DESCRIPTION
Add new functions (mpu_get_acc() and mpu_get_gyro()) to get samples from the return of mpu_sample_all(). We can call mpu_read_acc() and mpu_read_gyro() twice but the samples may not be synced. These functions are better for the applications with restrict synchronization requirement.
